### PR TITLE
Add scripts for reproducing RL baselines on additional models

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ GRPO
 bash run_qwen2.5-math-7b_grpo.sh
 ```
 
+Additional bash scripts are provided to reproduce the results on smaller model
+variants. The following scripts mirror the commands above but swap in the
+alternative checkpoints listed in `STATUS.md`:
+
+```
+bash run_llama-3b_psr_nsr.sh   # PSR/NSR/W-REINFORCE with Llama 3B
+bash run_llama-3b_ppo.sh       # PPO baseline for Llama 3B
+bash run_llama-3b_grpo.sh      # GRPO baseline for Llama 3B
+
+bash run_olmo-1b_psr_nsr.sh    # PSR/NSR/W-REINFORCE with OLMo 1B
+bash run_olmo-1b_ppo.sh        # PPO baseline for OLMo 1B
+bash run_olmo-1b_grpo.sh       # GRPO baseline for OLMo 1B
+
+bash run_olmo-7b_psr_nsr.sh    # PSR/NSR/W-REINFORCE with OLMo 7B
+bash run_olmo-7b_ppo.sh        # PPO baseline for OLMo 7B
+bash run_olmo-7b_grpo.sh       # GRPO baseline for OLMo 7B
+```
+
 ## Evaluation
 Specify `MODEL_PATH` and `OUTPUT_DIR` in `eval.sh`, then `bash eval.sh`.
 

--- a/run_llama-3b_grpo.sh
+++ b/run_llama-3b_grpo.sh
@@ -1,0 +1,53 @@
+export RAY_DEDUP_LOGS=0
+
+math_train_path=./data/math/train.parquet
+math_test_path=./data/math/test.parquet
+aime2025_test_path=./data/aime2025/test.parquet
+amc23_test_path=./data/amc23/test.parquet
+
+train_files="['$math_train_path']"
+test_files="['$math_test_path', '$aime2025_test_path', '$amc23_test_path']"
+kl_coef=0.001
+lr=1e-6
+model_name=meta-llama/Llama-3.2-3B-Instruct
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=grpo \
+    data.train_files="$train_files" \
+    data.val_files="$test_files" \
+    data.train_batch_size=1024 \
+    data.max_prompt_length=1024 \
+    data.max_response_length=3072 \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.actor.optim.lr=$lr \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=48000 \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=64000 \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=64000 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=256 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=$kl_coef \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    actor_rollout_ref.rollout.free_cache_engine=False \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.7 \
+    actor_rollout_ref.rollout.n=8 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    trainer.experiment_name="MATH-Llama-3B-GRPO" \
+    trainer.critic_warmup=0 \
+    trainer.logger=['wandb'] \
+    trainer.project_name='verl' \
+    trainer.n_gpus_per_node=8 \
+    +trainer.val_before_train=True \
+    trainer.nnodes=1 \
+    trainer.save_freq=7 \
+    trainer.test_freq=7 \
+    trainer.total_epochs=20 $@

--- a/run_llama-3b_ppo.sh
+++ b/run_llama-3b_ppo.sh
@@ -1,0 +1,57 @@
+export RAY_DEDUP_LOGS=0
+
+math_train_path=./data/math/train.parquet
+math_test_path=./data/math/test.parquet
+aime2025_test_path=./data/aime2025/test.parquet
+amc23_test_path=./data/amc23/test.parquet
+
+train_files="['$math_train_path']"
+test_files="['$math_test_path', '$aime2025_test_path', '$amc23_test_path']"
+kl_coef=0.001
+lr=1e-6
+model_name=meta-llama/Llama-3.2-3B-Instruct
+
+python3 -m verl.trainer.main_ppo \
+    data.train_files="$train_files" \
+    data.val_files="$test_files" \
+    data.train_batch_size=1024 \
+    data.max_prompt_length=1024 \
+    data.max_response_length=3072 \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.actor.optim.lr=$lr \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=48000 \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=64000 \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=64000 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=256 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    actor_rollout_ref.rollout.free_cache_engine=False \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.5 \
+    actor_rollout_ref.rollout.n=8 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    critic.optim.lr=1e-5 \
+    critic.model.use_remove_padding=True \
+    critic.model.path=$model_name \
+    critic.model.enable_gradient_checkpointing=True \
+    critic.ppo_max_token_len_per_gpu=64000 \
+    critic.model.fsdp_config.param_offload=False \
+    critic.model.fsdp_config.optimizer_offload=False \
+    trainer.experiment_name="MATH-Llama-3B-PPO" \
+    algorithm.kl_ctrl.kl_coef=$kl_coef \
+    trainer.critic_warmup=0 \
+    trainer.logger=['wandb'] \
+    trainer.project_name='verl' \
+    trainer.n_gpus_per_node=8 \
+    +trainer.val_before_train=True \
+    trainer.nnodes=1 \
+    trainer.save_freq=7 \
+    trainer.test_freq=7 \
+    trainer.total_epochs=20 $@

--- a/run_llama-3b_psr_nsr.sh
+++ b/run_llama-3b_psr_nsr.sh
@@ -1,0 +1,57 @@
+export RAY_DEDUP_LOGS=0
+
+math_train_path=./data/math/train.parquet
+math_test_path=./data/math/test.parquet
+aime2025_test_path=./data/aime2025/test.parquet
+amc23_test_path=./data/amc23/test.parquet
+
+train_files="['$math_train_path']"
+test_files="['$math_test_path', '$aime2025_test_path', '$amc23_test_path']"
+advantage="positive"   # PSR
+# advantage="negative"   # NSR
+# advantage="weighted"   # W-REINFORCE
+# positive_advantage_weight=0.1   # For W-REINFORCE only
+kl_coef=0.0
+lr=1e-6
+model_name=meta-llama/Llama-3.2-3B-Instruct
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=psr_nsr \
+    algorithm.advantage=$advantage \
+    data.train_files="$train_files" \
+    data.val_files="$test_files" \
+    data.train_batch_size=1024 \
+    data.max_prompt_length=1024 \
+    data.max_response_length=3072 \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.actor.optim.lr=$lr \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=48000 \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=64000 \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=64000 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=256 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    actor_rollout_ref.rollout.free_cache_engine=False \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.7 \
+    actor_rollout_ref.rollout.n=8 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    trainer.experiment_name="MATH-Llama-3B-$advantage" \
+    algorithm.kl_ctrl.kl_coef=$kl_coef \
+    trainer.critic_warmup=0 \
+    trainer.logger=['wandb'] \
+    trainer.project_name='verl' \
+    trainer.n_gpus_per_node=8 \
+    +trainer.val_before_train=True \
+    trainer.nnodes=1 \
+    trainer.save_freq=7 \
+    trainer.test_freq=7 \
+    trainer.total_epochs=20 $@
+    # algorithm.positive_advantage_weight=$positive_advantage_weight \

--- a/run_olmo-1b_grpo.sh
+++ b/run_olmo-1b_grpo.sh
@@ -1,0 +1,53 @@
+export RAY_DEDUP_LOGS=0
+
+math_train_path=./data/math/train.parquet
+math_test_path=./data/math/test.parquet
+aime2025_test_path=./data/aime2025/test.parquet
+amc23_test_path=./data/amc23/test.parquet
+
+train_files="['$math_train_path']"
+test_files="['$math_test_path', '$aime2025_test_path', '$amc23_test_path']"
+kl_coef=0.001
+lr=1e-6
+model_name=allenai/OLMo-2-0425-1B-Instruct
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=grpo \
+    data.train_files="$train_files" \
+    data.val_files="$test_files" \
+    data.train_batch_size=1024 \
+    data.max_prompt_length=1024 \
+    data.max_response_length=3072 \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.actor.optim.lr=$lr \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=48000 \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=64000 \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=64000 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=256 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=$kl_coef \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    actor_rollout_ref.rollout.free_cache_engine=False \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.7 \
+    actor_rollout_ref.rollout.n=8 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    trainer.experiment_name="MATH-OLMo-1B-GRPO" \
+    trainer.critic_warmup=0 \
+    trainer.logger=['wandb'] \
+    trainer.project_name='verl' \
+    trainer.n_gpus_per_node=8 \
+    +trainer.val_before_train=True \
+    trainer.nnodes=1 \
+    trainer.save_freq=7 \
+    trainer.test_freq=7 \
+    trainer.total_epochs=20 $@

--- a/run_olmo-1b_ppo.sh
+++ b/run_olmo-1b_ppo.sh
@@ -1,0 +1,57 @@
+export RAY_DEDUP_LOGS=0
+
+math_train_path=./data/math/train.parquet
+math_test_path=./data/math/test.parquet
+aime2025_test_path=./data/aime2025/test.parquet
+amc23_test_path=./data/amc23/test.parquet
+
+train_files="['$math_train_path']"
+test_files="['$math_test_path', '$aime2025_test_path', '$amc23_test_path']"
+kl_coef=0.001
+lr=1e-6
+model_name=allenai/OLMo-2-0425-1B-Instruct
+
+python3 -m verl.trainer.main_ppo \
+    data.train_files="$train_files" \
+    data.val_files="$test_files" \
+    data.train_batch_size=1024 \
+    data.max_prompt_length=1024 \
+    data.max_response_length=3072 \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.actor.optim.lr=$lr \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=48000 \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=64000 \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=64000 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=256 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    actor_rollout_ref.rollout.free_cache_engine=False \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.5 \
+    actor_rollout_ref.rollout.n=8 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    critic.optim.lr=1e-5 \
+    critic.model.use_remove_padding=True \
+    critic.model.path=$model_name \
+    critic.model.enable_gradient_checkpointing=True \
+    critic.ppo_max_token_len_per_gpu=64000 \
+    critic.model.fsdp_config.param_offload=False \
+    critic.model.fsdp_config.optimizer_offload=False \
+    trainer.experiment_name="MATH-OLMo-1B-PPO" \
+    algorithm.kl_ctrl.kl_coef=$kl_coef \
+    trainer.critic_warmup=0 \
+    trainer.logger=['wandb'] \
+    trainer.project_name='verl' \
+    trainer.n_gpus_per_node=8 \
+    +trainer.val_before_train=True \
+    trainer.nnodes=1 \
+    trainer.save_freq=7 \
+    trainer.test_freq=7 \
+    trainer.total_epochs=20 $@

--- a/run_olmo-1b_psr_nsr.sh
+++ b/run_olmo-1b_psr_nsr.sh
@@ -1,0 +1,57 @@
+export RAY_DEDUP_LOGS=0
+
+math_train_path=./data/math/train.parquet
+math_test_path=./data/math/test.parquet
+aime2025_test_path=./data/aime2025/test.parquet
+amc23_test_path=./data/amc23/test.parquet
+
+train_files="['$math_train_path']"
+test_files="['$math_test_path', '$aime2025_test_path', '$amc23_test_path']"
+advantage="positive"   # PSR
+# advantage="negative"   # NSR
+# advantage="weighted"   # W-REINFORCE
+# positive_advantage_weight=0.1   # For W-REINFORCE only
+kl_coef=0.0
+lr=1e-6
+model_name=allenai/OLMo-2-0425-1B-Instruct
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=psr_nsr \
+    algorithm.advantage=$advantage \
+    data.train_files="$train_files" \
+    data.val_files="$test_files" \
+    data.train_batch_size=1024 \
+    data.max_prompt_length=1024 \
+    data.max_response_length=3072 \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.actor.optim.lr=$lr \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=48000 \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=64000 \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=64000 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=256 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    actor_rollout_ref.rollout.free_cache_engine=False \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.7 \
+    actor_rollout_ref.rollout.n=8 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    trainer.experiment_name="MATH-OLMo-1B-$advantage" \
+    algorithm.kl_ctrl.kl_coef=$kl_coef \
+    trainer.critic_warmup=0 \
+    trainer.logger=['wandb'] \
+    trainer.project_name='verl' \
+    trainer.n_gpus_per_node=8 \
+    +trainer.val_before_train=True \
+    trainer.nnodes=1 \
+    trainer.save_freq=7 \
+    trainer.test_freq=7 \
+    trainer.total_epochs=20 $@
+    # algorithm.positive_advantage_weight=$positive_advantage_weight \

--- a/run_olmo-7b_grpo.sh
+++ b/run_olmo-7b_grpo.sh
@@ -1,0 +1,53 @@
+export RAY_DEDUP_LOGS=0
+
+math_train_path=./data/math/train.parquet
+math_test_path=./data/math/test.parquet
+aime2025_test_path=./data/aime2025/test.parquet
+amc23_test_path=./data/amc23/test.parquet
+
+train_files="['$math_train_path']"
+test_files="['$math_test_path', '$aime2025_test_path', '$amc23_test_path']"
+kl_coef=0.001
+lr=1e-6
+model_name=allenai/OLMo-2-1124-7B-Instruct
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=grpo \
+    data.train_files="$train_files" \
+    data.val_files="$test_files" \
+    data.train_batch_size=1024 \
+    data.max_prompt_length=1024 \
+    data.max_response_length=3072 \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.actor.optim.lr=$lr \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=48000 \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=64000 \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=64000 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=256 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=$kl_coef \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    actor_rollout_ref.rollout.free_cache_engine=False \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.7 \
+    actor_rollout_ref.rollout.n=8 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    trainer.experiment_name="MATH-OLMo-7B-GRPO" \
+    trainer.critic_warmup=0 \
+    trainer.logger=['wandb'] \
+    trainer.project_name='verl' \
+    trainer.n_gpus_per_node=8 \
+    +trainer.val_before_train=True \
+    trainer.nnodes=1 \
+    trainer.save_freq=7 \
+    trainer.test_freq=7 \
+    trainer.total_epochs=20 $@

--- a/run_olmo-7b_ppo.sh
+++ b/run_olmo-7b_ppo.sh
@@ -1,0 +1,57 @@
+export RAY_DEDUP_LOGS=0
+
+math_train_path=./data/math/train.parquet
+math_test_path=./data/math/test.parquet
+aime2025_test_path=./data/aime2025/test.parquet
+amc23_test_path=./data/amc23/test.parquet
+
+train_files="['$math_train_path']"
+test_files="['$math_test_path', '$aime2025_test_path', '$amc23_test_path']"
+kl_coef=0.001
+lr=1e-6
+model_name=allenai/OLMo-2-1124-7B-Instruct
+
+python3 -m verl.trainer.main_ppo \
+    data.train_files="$train_files" \
+    data.val_files="$test_files" \
+    data.train_batch_size=1024 \
+    data.max_prompt_length=1024 \
+    data.max_response_length=3072 \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.actor.optim.lr=$lr \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=48000 \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=64000 \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=64000 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=256 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    actor_rollout_ref.rollout.free_cache_engine=False \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.5 \
+    actor_rollout_ref.rollout.n=8 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    critic.optim.lr=1e-5 \
+    critic.model.use_remove_padding=True \
+    critic.model.path=$model_name \
+    critic.model.enable_gradient_checkpointing=True \
+    critic.ppo_max_token_len_per_gpu=64000 \
+    critic.model.fsdp_config.param_offload=False \
+    critic.model.fsdp_config.optimizer_offload=False \
+    trainer.experiment_name="MATH-OLMo-7B-PPO" \
+    algorithm.kl_ctrl.kl_coef=$kl_coef \
+    trainer.critic_warmup=0 \
+    trainer.logger=['wandb'] \
+    trainer.project_name='verl' \
+    trainer.n_gpus_per_node=8 \
+    +trainer.val_before_train=True \
+    trainer.nnodes=1 \
+    trainer.save_freq=7 \
+    trainer.test_freq=7 \
+    trainer.total_epochs=20 $@

--- a/run_olmo-7b_psr_nsr.sh
+++ b/run_olmo-7b_psr_nsr.sh
@@ -1,0 +1,57 @@
+export RAY_DEDUP_LOGS=0
+
+math_train_path=./data/math/train.parquet
+math_test_path=./data/math/test.parquet
+aime2025_test_path=./data/aime2025/test.parquet
+amc23_test_path=./data/amc23/test.parquet
+
+train_files="['$math_train_path']"
+test_files="['$math_test_path', '$aime2025_test_path', '$amc23_test_path']"
+advantage="positive"   # PSR
+# advantage="negative"   # NSR
+# advantage="weighted"   # W-REINFORCE
+# positive_advantage_weight=0.1   # For W-REINFORCE only
+kl_coef=0.0
+lr=1e-6
+model_name=allenai/OLMo-2-1124-7B-Instruct
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=psr_nsr \
+    algorithm.advantage=$advantage \
+    data.train_files="$train_files" \
+    data.val_files="$test_files" \
+    data.train_batch_size=1024 \
+    data.max_prompt_length=1024 \
+    data.max_response_length=3072 \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.actor.optim.lr=$lr \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=48000 \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=64000 \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=64000 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=256 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    actor_rollout_ref.rollout.free_cache_engine=False \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.7 \
+    actor_rollout_ref.rollout.n=8 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    trainer.experiment_name="MATH-OLMo-7B-$advantage" \
+    algorithm.kl_ctrl.kl_coef=$kl_coef \
+    trainer.critic_warmup=0 \
+    trainer.logger=['wandb'] \
+    trainer.project_name='verl' \
+    trainer.n_gpus_per_node=8 \
+    +trainer.val_before_train=True \
+    trainer.nnodes=1 \
+    trainer.save_freq=7 \
+    trainer.test_freq=7 \
+    trainer.total_epochs=20 $@
+    # algorithm.positive_advantage_weight=$positive_advantage_weight \


### PR DESCRIPTION
## Summary
- provide GRPO, PPO, and PSR/NSR runner scripts for Llama-3B and OLMo 1B & 7B
- document these new scripts in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6851aefea9c0832f8a54c5dfaf3c57ed